### PR TITLE
Start an enter password test.

### DIFF
--- a/apps/system/test/unit/fxa_test/mock_fxam_server_request.js
+++ b/apps/system/test/unit/fxa_test/mock_fxam_server_request.js
@@ -21,7 +21,7 @@ var MockFxModuleServerRequest = {
       onerror && onerror();
     }
   },
-  checkPassword: function(email, password, onsuccess, onerror) {
+  signIn: function(email, password, onsuccess, onerror) {
     if (!this.error) {
       setTimeout(function() {
         var params = {
@@ -33,7 +33,7 @@ var MockFxModuleServerRequest = {
       onerror && onerror();
     }
   },
-  createAccount: function(email, password, onsuccess, onerror) {
+  signUp: function(email, password, onsuccess, onerror) {
     if (!this.error) {
       setTimeout(function() {
         var params = {

--- a/apps/system/test/unit/fxa_test/screens/fxam_enter_password_test.js
+++ b/apps/system/test/unit/fxa_test/screens/fxam_enter_password_test.js
@@ -1,0 +1,195 @@
+'use strict';
+
+// Helper for loading the elements
+requireApp('/system/test/unit/fxa_test/load_element_helper.js');
+
+// Real code
+requireApp('system/fxa/js/utils.js');
+requireApp('system/fxa/js/fxam_module.js');
+requireApp('system/fxa/js/fxam_states.js');
+requireApp('system/fxa/js/fxam_manager.js');
+requireApp('system/fxa/js/fxam_overlay.js');
+requireApp('system/fxa/js/fxam_error_overlay.js');
+
+// Mockuped code
+requireApp('/system/test/unit/mock_l10n.js');
+
+requireApp('system/fxa/js/fxam_ui.js');
+requireApp('/system/test/unit/fxa_test/mock_fxam_ui.js');
+requireApp('system/fxa/js/fxam_server_request.js');
+requireApp('/system/test/unit/fxa_test/mock_fxam_server_request.js');
+
+require('/shared/js/lazy_loader.js');
+require('/shared/test/unit/mocks/mock_lazy_loader.js');
+
+require('/shared/test/unit/mocks/mocks_helper.js');
+require('/shared/test/unit/load_body_html_helper.js');
+
+// Code to test
+requireApp('system/fxa/js/screens/fxam_enter_password.js');
+
+var mocksHelperForEnterPassword = new MocksHelper([
+  'LazyLoader',
+  'FxaModuleUI',
+  'FxModuleServerRequest'
+]);
+
+suite('Screen: Enter password', function() {
+  var realL10n;
+  suiteSetup(function(done) {
+    realL10n = navigator.mozL10n;
+    navigator.mozL10n = MockL10n;
+
+    mocksHelperForEnterPassword.suiteSetup();
+    // Load real HTML
+    loadBodyHTML('/fxa/fxa_module.html');
+    // Load element to test
+    LoadElementHelper.load('fxa-enter-password.html');
+    // Import the element and execute the right init
+    HtmlImports.populate(function() {
+      FxaModuleEnterPassword.init({
+        email: 'testuser@testuser.com'
+      });
+      done();
+    });
+  });
+
+  suiteTeardown(function() {
+    navigator.mozL10n = realL10n;
+    document.body.innerHTML = '';
+    mocksHelperForEnterPassword.suiteTeardown();
+  });
+
+
+  suite(' > password input ', function() {
+    var passwordInput;
+    var fxamUIDisableSpy, fxamUIEnableSpy;
+    var inputEvent;
+    setup(function() {
+      passwordInput = document.getElementById('fxa-pw-input');
+      fxamUIDisableSpy = this.sinon.spy(FxaModuleUI, 'disableNextButton');
+      fxamUIEnableSpy = this.sinon.spy(FxaModuleUI, 'enableNextButton');
+      inputEvent = new CustomEvent(
+        'input',
+        {
+          bubbles: true
+        }
+      );
+      mocksHelperForEnterPassword.setup();
+    });
+
+    teardown(function() {
+      passwordInput = null;
+      fxamUIDisableSpy = null;
+      fxamUIEnableSpy = null;
+      mocksHelperForEnterPassword.teardown();
+    });
+
+    test(' > Disabled button at the beginning', function() {
+      passwordInput.dispatchEvent(inputEvent);
+
+      assert.ok(fxamUIDisableSpy.calledOnce);
+      assert.isFalse(fxamUIEnableSpy.calledOnce);
+    });
+
+    test(' > Enable when ready', function() {
+      passwordInput.value = 'myawesomepassword';
+      passwordInput.dispatchEvent(inputEvent);
+
+      assert.ok(fxamUIEnableSpy.calledOnce);
+      assert.isFalse(fxamUIDisableSpy.calledOnce);
+    });
+
+    test(' > Changes in the password input are tracked properly', function() {
+      passwordInput.value = 'longpassword';
+      passwordInput.dispatchEvent(inputEvent);
+
+      assert.ok(fxamUIEnableSpy.called);
+      assert.isFalse(fxamUIDisableSpy.calledOnce);
+
+      // Change the value on the fly
+      passwordInput.value = 'short';
+      passwordInput.dispatchEvent(inputEvent);
+
+      assert.ok(fxamUIEnableSpy.calledOnce);
+      assert.ok(fxamUIDisableSpy.called);
+    });
+  });
+
+  suite(' > onNext ', function() {
+    var showOverlaySpy, showErrorOverlaySpy, hideOverlaySpy;
+    setup(function() {
+      showErrorOverlaySpy = this.sinon.spy(FxaModuleErrorOverlay, 'show');
+      showOverlaySpy = this.sinon.spy(FxaModuleOverlay, 'show');
+      hideOverlaySpy = this.sinon.spy(FxaModuleOverlay, 'hide');
+      mocksHelperForEnterPassword.setup();
+    });
+
+    teardown(function() {
+      showErrorOverlaySpy = null;
+      showOverlaySpy = null;
+      hideOverlaySpy = null;
+      mocksHelperForEnterPassword.teardown();
+      FxModuleServerRequest.error = false;
+      FxModuleServerRequest.registered = false;
+    });
+
+    test(' > Overlay shown', function(done) {
+      FxaModuleEnterPassword.onNext(function() {
+        assert.ok(showOverlaySpy.calledOnce);
+        done();
+      });
+    });
+
+    suite(' > signIn called', function() {
+      var checkPasswordSpy;
+      setup(function() {
+        checkPasswordSpy =
+            this.sinon.spy(FxModuleServerRequest, 'signIn');
+        mocksHelperForEnterPassword.setup();
+      });
+
+      teardown(function() {
+        checkPasswordSpy = null;
+        mocksHelperForEnterPassword.teardown();
+      });
+
+      test(' > Check password', function(done) {
+        FxaModuleEnterPassword.onNext(function() {
+          assert.ok(checkPasswordSpy.calledOnce);
+          done();
+        });
+      });
+    });
+
+    test(' > Network error', function() {
+      FxModuleServerRequest.error = true;
+      FxaModuleEnterPassword.onNext(function() {});
+
+      assert.ok(hideOverlaySpy.calledOnce);
+      assert.ok(showErrorOverlaySpy.calledOnce);
+    });
+
+    test(' > Valid password', function(done) {
+      FxModuleServerRequest.error = false;
+      FxModuleServerRequest.authenticated = true;
+      FxaModuleEnterPassword.onNext(function(params) {
+        assert.equal(params, FxaModuleStates.SIGNIN_SUCCESS);
+        assert.ok(hideOverlaySpy.calledOnce);
+        assert.isFalse(showErrorOverlaySpy.calledOnce);
+        done();
+      });
+    });
+
+    test(' > Invalid password', function(done) {
+      FxModuleServerRequest.error = false;
+      FxModuleServerRequest.authenticated = false;
+      FxaModuleEnterPassword.onNext(function(params) {
+        assert.equal(params, null);
+        assert.ok(hideOverlaySpy.calledOnce);
+        assert.ok(showErrorOverlaySpy.calledOnce);
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
- Ensure the onNext always calls the done callback so password incorrect can be tested.
- Update the server mock to use the new functions signIn and signUp.

@borjasalguero, @sergi - how is this looking for a set of tests for enter password? One thing I have changed is that onNext always calls the "done" callback whenever FxamServerRequest calls its onSuccess callback. This is so we can test things like "password incorrect" which are taken care of in the success handler instead of the error handler.
